### PR TITLE
Fix full-height issue

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main>
+      <main className="h-full">
         <Signin />
       </main>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
+
+#__next {
+  height: 100%;
+}
+
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
Fixes issue where template doesn't render as full-height. The trick with these sorts of layouts is that _every_ element in the tree from the `html` tag down to the wrapped element that needs to be full height needs `height: 100%` set, otherwise the height gets "lost" in the tree. So the more wrappers you have, the more you need to set it.

In this case, Next.js adds the `#__next` wrapper without you being able to control it directly, and you have that `main` element you've added so we need to set `height: 100%` on both of those 👍 